### PR TITLE
Setup info

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,13 @@
 * a demo program (which shows the usage of most library functions)
 * info on OLED and LCD character displays that work with this software
 * hardware design for a backpack board for LCDs and OLEDs, available on github
-* info on backpack “bare” pc boards available from OSH Park.
+* info on backpack "bare" pc boards available from OSH Park.
+
+**Installation** - 
+To install the library directly from github, you can enter the following from a command prompt on your Raspberry Pi:
+```bash
+pip3 install git+https://github.com/dcityorg/i2c-char-display-library-raspberrypi.git
+```
 
 **License Information**
 License Information is [here](https://www.dcity.org/license-information/).

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,5 @@ setup(
     ],
     keywords='RPi US2066 HD44780 I2C interface OLED LCD',
     py_modules=['I2cCharDisplay'],
-    install_requires=['smbus2'],    
+    install_requires=['smbus'],    
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,28 @@
+from setuptools import setup
+
+setup(
+    name='I2cCharDisplay',
+    version='1.0.1',
+    description='Raspberry Pi software library for controlling I²C character LCD and OLED Displays',
+    long_description=open('README.md').read(),
+    url='https://github.com/dcityorg/i2c-char-display-library-raspberrypi',
+    author='Gary Muhonen',
+    author_email='gary@dcity.org',
+    license='MIT',
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'Topic :: System :: Hardware',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+    ],
+    keywords='RPi US2066 HD44780 I2C interface OLED LCD',
+    py_modules=['I2cCharDisplay'],
+    install_requires=['smbus2'],    
+)


### PR DESCRIPTION
I created a setup.py file to allow this library to be installed via PIP directly from your github repo.  In addition to installing the I2cCharDisplay.py library file, this will also install the smbus dependency required by your library.

The README file was also updated with a PIP installation example in order to utilize it.  I also changed the unicode quote marks that were in that file with ascii compatible quotes to insure it works with PIP.